### PR TITLE
Add email and help UI elements

### DIFF
--- a/app/src/main/java/com/example/codexone/MainActivity.kt
+++ b/app/src/main/java/com/example/codexone/MainActivity.kt
@@ -18,18 +18,21 @@ class MainActivity : AppCompatActivity() {
 
         // Get references to the views
         val usernameEditText: EditText = findViewById(R.id.usernameEditText)
+        val emailEditText: EditText = findViewById(R.id.emailEditText)
         val passwordEditText: EditText = findViewById(R.id.passwordEditText)
         val loginButton: Button = findViewById(R.id.loginButton)
         val forgotPasswordText: TextView = findViewById(R.id.forgotPasswordText)
+        val helpButton: Button = findViewById(R.id.helpButton)
 
         // Set a click listener for the login button
         loginButton.setOnClickListener {
             val username = usernameEditText.text.toString()
+            val email = emailEditText.text.toString()
             val password = passwordEditText.text.toString()
 
             // Basic validation
-            if (username.isEmpty() || password.isEmpty()) {
-                Toast.makeText(this, "Please enter both username and password", Toast.LENGTH_SHORT).show()
+            if (username.isEmpty() || email.isEmpty() || password.isEmpty()) {
+                Toast.makeText(this, "Please fill in all fields", Toast.LENGTH_SHORT).show()
             } else {
                 // In a real app, you would check credentials here
                 // For this example, we'll just show a Toast
@@ -37,6 +40,10 @@ class MainActivity : AppCompatActivity() {
 
                 // You can navigate to another activity if login is successful
             }
+        }
+
+        helpButton.setOnClickListener {
+            Toast.makeText(this, "Help clicked", Toast.LENGTH_SHORT).show()
         }
 
         // Set a click listener for the forgot password text

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,6 +13,16 @@
         android:inputType="textEmailAddress"
         android:layout_marginBottom="16dp"/>
 
+    <!-- Email EditText -->
+    <EditText
+        android:id="@+id/emailEditText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Email"
+        android:inputType="textEmailAddress"
+        android:layout_below="@id/usernameEditText"
+        android:layout_marginBottom="16dp"/>
+
     <!-- Password EditText -->
     <EditText
         android:id="@+id/passwordEditText"
@@ -20,7 +30,7 @@
         android:layout_height="wrap_content"
         android:hint="Password"
         android:inputType="textPassword"
-        android:layout_below="@id/usernameEditText"
+        android:layout_below="@id/emailEditText"
         android:layout_marginBottom="16dp"/>
 
     <!-- Login Button -->
@@ -40,4 +50,14 @@
         android:textColor="#0000FF"
         android:layout_below="@id/loginButton"
         android:layout_marginTop="10dp"/>
+
+    <!-- Help Button -->
+    <Button
+        android:id="@+id/helpButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Help"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_margin="16dp" />
 </RelativeLayout>


### PR DESCRIPTION
## Summary
- extend login layout with email field and help button
- update `MainActivity` to reference new views
- validate email along with username and password
- show a toast when Help is tapped

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685685f1b3e0832d8ce8ea285e5b4e62